### PR TITLE
Add paper links to modals

### DIFF
--- a/components/onboarding-modal.tsx
+++ b/components/onboarding-modal.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { motion, AnimatePresence } from "framer-motion"
-import { X, ArrowRight, Sparkles, Archive, Network, Shield } from "lucide-react"
+import { X, ArrowRight, Sparkles, Archive, Network, Shield, FileText } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useState, useEffect, useCallback } from "react"
 import { useVerboseMode } from "@/lib/utils"
@@ -11,17 +11,32 @@ interface OnboardingModalProps {
   title: string
   content: string
   actionLabel?: string
-  modalType: 'preferences' | 'authority' | 'application'
+  modalType: 'chat' | 'preferences' | 'negotiation' | 'authority'
 }
 
 // Single card content for each modal type
-const modalContent: Record<'preferences' | 'authority' | 'application', {
+const modalContent: Record<'chat' | 'preferences' | 'negotiation' | 'authority', {
   title: string
   subtitle: string
   content: string
-  visual: 'data' | 'authority' | 'agents'
+  visual: 'chat' | 'data' | 'authority' | 'agents'
   keyPoints: string[]
+  paperLink?: {
+    url: string
+    title: string
+  }
 }> = {
+  chat: {
+    title: "Chatbots Are Becoming Our Friends",
+    subtitle: "The new interface for human-AI interaction",
+    content: "Every day when you talk with Claude or ChatGPT, they are implicitly storing and remembering information about you and your preferences. This is how they achieve market lock-in.",
+    visual: 'chat',
+    keyPoints: [
+      "Natural conversation interface",
+      "Implicit preference learning",
+      "Creates vendor lock-in"
+    ]
+  },
   preferences: {
     title: "The Importance of Human Context",
     subtitle: "Your preferences are the foundation of AI utility",
@@ -31,6 +46,21 @@ const modalContent: Record<'preferences' | 'authority' | 'application', {
       "Transparent: You can see and control your data",
       "Interoperable: Works across different AI services",
       "Secure: Protected by design and encrypted"
+    ],
+    paperLink: {
+      url: "https://hcp.loyalagents.org/hcp-paper.pdf",
+      title: "Human Context Protocol Paper"
+    }
+  },
+  negotiation: {
+    title: "AI Agents Acting on Your Behalf",
+    subtitle: "The future of autonomous AI interaction",
+    content: "With portable human context, AI agents can negotiate on your behalf with deep understanding of your preferences. This enables a future where multiple AI systems can collaborate while respecting your individual needs and values.",
+    visual: 'agents',
+    keyPoints: [
+      "Agents understand your preferences",
+      "Multi-agent collaboration",
+      "Preserves your values in negotiations"
     ]
   },
   authority: {
@@ -42,18 +72,11 @@ const modalContent: Record<'preferences' | 'authority' | 'application', {
       "Define precise access rules for each AI service",
       "Set autonomy levels based on trust and task",
       "Maintain complete audit trail of all access"
-    ]
-  },
-  application: {
-    title: "Bringing It All Together",
-    subtitle: "Context + Authority = Powerful AI",
-    content: "When human context and grant of authority combine, they unlock a new paradigm of AI interaction. Your preferences guide AI behavior across native chat applications, MCP protocols, and agent-to-agent negotiations - all while maintaining your control and privacy.",
-    visual: 'agents',
-    keyPoints: [
-      "Seamless AI experiences across all platforms",
-      "Agents that truly represent your interests",
-      "Transparent, controllable, and trustworthy"
-    ]
+    ],
+    paperLink: {
+      url: "https://hcp.loyalagents.org/authentic-AI-whitepaper.pdf",
+      title: "Authentication, Authorization, and Identity for Agents"
+    }
   }
 }
 
@@ -91,6 +114,7 @@ export function OnboardingModal({
   
   const getVisualIcon = (visual: string) => {
     switch (visual) {
+      case 'chat': return Sparkles
       case 'data': return Archive
       case 'agents': return Network
       case 'authority': return Shield
@@ -139,28 +163,10 @@ export function OnboardingModal({
                   <X className="w-4 h-4 sm:w-5 sm:h-5 text-muted-foreground group-hover:text-foreground transition-colors" />
                 </motion.button>
                 
-                {/* Progress indicator */}
-                <div className="flex gap-1.5 sm:gap-2 mb-4 sm:mb-6">
-                  {story.map((_, index) => (
-                    <motion.div
-                      key={index}
-                      className={`h-1 rounded-full flex-1 ${
-                        index <= currentStep ? 'bg-primary' : 'bg-muted'
-                      }`}
-                      initial={{ scaleX: 0 }}
-                      animate={{ 
-                        scaleX: index <= currentStep ? 1 : 0.3,
-                        backgroundColor: index <= currentStep ? 'oklch(0.385 0.127 265)' : 'oklch(0.925 0.01 83)'
-                      }}
-                      transition={{ duration: 0.5, delay: index * 0.1 }}
-                    />
-                  ))}
-                </div>
                 
                 {/* Visual icon */}
                 <motion.div 
                   className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center"
-                  key={currentStep}
                   initial={{ scale: 0, rotate: -180 }}
                   animate={{ scale: 1, rotate: 0 }}
                   transition={{ type: "spring", duration: 0.6 }}
@@ -170,103 +176,99 @@ export function OnboardingModal({
               </div>
               
               {/* Content */}
-              <AnimatePresence mode="wait">
-                <motion.div
-                  key={currentStep}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: isTransitioning ? 0 : 1, y: isTransitioning ? -20 : 0 }}
-                  exit={{ opacity: 0, y: -20 }}
-                  transition={{ duration: 0.3 }}
-                  className="px-4 pb-3 sm:px-8 sm:pb-4 md:px-10"
-                >
-                  <div className="text-center mb-6 sm:mb-8">
-                    <motion.h2 
-                      className="text-2xl sm:text-3xl md:text-4xl mb-2 font-light"
-                      style={{ fontFamily: 'var(--font-crimson)' }}
-                      initial={{ opacity: 0, y: 10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.2 }}
-                    >
-                      {step?.title}
-                    </motion.h2>
-                    {step?.subtitle && (
-                      <motion.p 
-                        className="text-sm sm:text-base text-primary/80 font-medium"
-                        initial={{ opacity: 0, y: 10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.3 }}
-                      >
-                        {step.subtitle}
-                      </motion.p>
-                    )}
-                  </div>
-                  
-                  <motion.p 
-                    className="text-sm sm:text-base text-muted-foreground leading-[1.6] sm:leading-[1.7] text-center mb-6 sm:mb-8 max-w-sm sm:max-w-lg mx-auto"
+              <div className="px-4 pb-3 sm:px-8 sm:pb-4 md:px-10">
+                <div className="text-center mb-6 sm:mb-8">
+                  <motion.h2 
+                    className="text-2xl sm:text-3xl md:text-4xl mb-2 font-light"
+                    style={{ fontFamily: 'var(--font-crimson)' }}
                     initial={{ opacity: 0, y: 10 }}
                     animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.4 }}
+                    transition={{ delay: 0.2 }}
                   >
-                    {step?.content}
-                  </motion.p>
-                  
-                  {/* Key insights - only show when VERBOSE_DISPLAY=true */}
-                  {showVerboseDisplay && (
-                    <motion.div 
-                      className="bg-muted/20 rounded-xl p-3 sm:p-6 mb-4 sm:mb-8"
-                      initial={{ opacity: 0, y: 20 }}
+                    {content?.title}
+                  </motion.h2>
+                  {content?.subtitle && (
+                    <motion.p 
+                      className="text-sm sm:text-base text-primary/80 font-medium"
+                      initial={{ opacity: 0, y: 10 }}
                       animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.5 }}
+                      transition={{ delay: 0.3 }}
                     >
-                      <h4 className="font-medium mb-4 text-center" style={{ fontFamily: 'var(--font-crimson)' }}>Key Insights</h4>
-                      <div className="space-y-3">
-                        {step?.insights.map((insight, index) => (
-                          <motion.div
-                            key={index}
-                            className="flex items-start gap-3"
-                            initial={{ opacity: 0, x: -20 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            transition={{ delay: 0.6 + index * 0.1 }}
-                          >
-                            <div className="w-1.5 h-1.5 rounded-full bg-primary mt-2.5 flex-shrink-0" />
-                            <p className="text-sm text-muted-foreground leading-relaxed">{insight}</p>
-                          </motion.div>
-                        ))}
-                      </div>
-                    </motion.div>
+                      {content.subtitle}
+                    </motion.p>
                   )}
-                </motion.div>
-              </AnimatePresence>
+                </div>
+                
+                <motion.p 
+                  className="text-sm sm:text-base text-muted-foreground leading-[1.6] sm:leading-[1.7] text-center mb-6 sm:mb-8 max-w-sm sm:max-w-lg mx-auto"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.4 }}
+                >
+                  {content?.content}
+                </motion.p>
+                
+                {/* Paper Link Button - subtle and tasteful */}
+                {content?.paperLink && (
+                  <motion.div
+                    className="flex justify-center mb-6"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.45 }}
+                  >
+                    <a
+                      href={content.paperLink.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 px-4 py-2 text-xs sm:text-sm text-muted-foreground hover:text-foreground bg-muted/10 hover:bg-muted/20 rounded-lg transition-all duration-200 group"
+                    >
+                      <FileText className="w-3.5 h-3.5 sm:w-4 sm:h-4 transition-transform group-hover:scale-110" />
+                      <span className="font-medium">Read the Paper</span>
+                      <ArrowRight className="w-3 h-3 sm:w-3.5 sm:h-3.5 opacity-0 -ml-1 group-hover:opacity-100 group-hover:ml-0 transition-all duration-200" />
+                    </a>
+                  </motion.div>
+                )}
+                
+                {/* Key insights - only show when VERBOSE_DISPLAY=true */}
+                {showVerboseDisplay && content?.keyPoints && (
+                  <motion.div 
+                    className="bg-muted/20 rounded-xl p-3 sm:p-6 mb-4 sm:mb-8"
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.5 }}
+                  >
+                    <h4 className="font-medium mb-4 text-center" style={{ fontFamily: 'var(--font-crimson)' }}>Key Points</h4>
+                    <div className="space-y-3">
+                      {content.keyPoints.map((point, index) => (
+                        <motion.div
+                          key={index}
+                          className="flex items-start gap-3"
+                          initial={{ opacity: 0, x: -20 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ delay: 0.6 + index * 0.1 }}
+                        >
+                          <div className="w-1.5 h-1.5 rounded-full bg-primary mt-2.5 flex-shrink-0" />
+                          <p className="text-sm text-muted-foreground leading-relaxed">{point}</p>
+                        </motion.div>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </div>
               
               {/* Actions */}
               <div className="px-4 pb-4 sm:px-8 sm:pb-8 md:px-10 md:pb-10">
-                <div className="flex justify-between items-center gap-4">
-                  <motion.p 
-                    className="text-xs sm:text-sm text-muted-foreground"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ delay: 0.8 }}
-                  >
-                    {currentStep + 1} of {story.length}
-                  </motion.p>
-                  
+                <div className="flex justify-end">
                   <motion.div
                     initial={{ opacity: 0, y: 10 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.7 }}
                   >
                     <Button 
-                      onClick={handleNext}
+                      onClick={handleClose}
                       className="bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-3 sm:px-6 sm:py-2.5 md:px-8 md:py-3 rounded-lg flex items-center gap-2 text-sm sm:text-base"
                     >
-                      {currentStep < story.length - 1 ? (
-                        <>
-                          Continue
-                          <ArrowRight className="w-4 h-4" />
-                        </>
-                      ) : (
-                        actionLabel
-                      )}
+                      {actionLabel}
                     </Button>
                   </motion.div>
                 </div>


### PR DESCRIPTION
Add subtle paper link buttons to the Human Context and Grant of Authority modals, and refactor the OnboardingModal component for correct functionality.

The existing `OnboardingModal` component had issues with undefined variables and an incomplete `modalType` prop handling, which required a refactor to properly integrate the new paper links and ensure the modal functions correctly across all intended types.

---
<a href="https://cursor.com/background-agent?bcId=bc-40e791ae-1cc6-4729-8bd0-67ae568af4dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40e791ae-1cc6-4729-8bd0-67ae568af4dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

